### PR TITLE
added one hot encoding to NN model

### DIFF
--- a/model_neuralnet.ipynb
+++ b/model_neuralnet.ipynb
@@ -28,7 +28,6 @@
     "from sklearn.neural_network import MLPClassifier\n",
     "from sklearn.pipeline import make_pipeline\n",
     "from sklearn.preprocessing import Imputer\n",
-    "from sklearn.preprocessing import LabelEncoder\n",
     "from sklearn.preprocessing import OneHotEncoder\n",
     "from sklearn.preprocessing import StandardScaler\n",
     "\n",


### PR DESCRIPTION
I added one hot encoding to `model_neuralnet.ipynb`.  This is required if we want to include `district` or `zip` in *any* model, because we need to make sure they are not treated as integers, but as factors.

It's a little fragile right now, but you should be able to get the idea  of the code.  Since this is something that should be done for any model, I think we probably want to do this in `prep_merge.ipynb`.  However, the output of the one hot encoding is a sparse matrix, so I wasn't sure if that would write out to a csv well.  I'll spend some time on that later tonight (or tomorrow), but wanted to go ahead and submit this commit so you could see the code in action.