### PR TITLE
more NN tuning

### DIFF
--- a/model_neuralnet.ipynb
+++ b/model_neuralnet.ipynb
@@ -65,6 +65,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> **KEY OBSERVATION**: the feature `school_income_estimate` only has non-null values for 132 of 464 records.  We should drop it from further analysis, as imputing its value for the non-null records isn't appropriate."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -80,7 +87,7 @@
    "metadata": {},
    "source": [
     "## Train and fit a \"naive\" model\n",
-    "For the first model, we'll use all features except SHSAT-related features because they are too correlated with the way we calculated the label."
+    "For the first model, we'll use all features except SHSAT-related features because they are too correlated with the way we calculated the label.  We'll also drop `school_income_estimate` because it's missing for ~2/3 of the schools."
    ]
   },
   {
@@ -95,6 +102,7 @@
     "             'pct_test_takers',\n",
     "             'high_registrations',\n",
     "             'school_name',\n",
+    "             'school_income_estimate',\n",
     "#              'district',\n",
     "#              'zip',\n",
     "            ]\n",
@@ -111,9 +119,7 @@
    "source": [
     "### Impute missing values\n",
     "\n",
-    "The sklearn estimators assume that all values in an array are numerical, and have meaning, so we need to replace `NaN` values.  We choose to use the column means for this imputation.\n",
-    "\n",
-    "> WARNING: this may be problematic for `school_income_estimate` (~2/3 of rows hold nulls)"
+    "The sklearn estimators assume that all values in an array are numerical, and have meaning, so we need to replace `NaN` values.  We choose to use the column means for this imputation."
    ]
   },
   {
@@ -125,12 +131,7 @@
     "# impute missing values by setting them to the column mean\n",
     "imp = Imputer(missing_values='NaN', strategy='mean', axis=0)\n",
     "imp.fit(X)\n",
-    "X_imputed = imp.transform(X)\n",
-    "\n",
-    "# preview a few rows, post-processed\n",
-    "print(X_imputed.shape)\n",
-    "# confirm col 4 shouldn't be altered; NaNs should be replaced in col 5\n",
-    "print(X_imputed[0:5,4:6])  "
+    "X_imputed = imp.transform(X)"
    ]
   },
   {
@@ -138,7 +139,7 @@
    "metadata": {},
    "source": [
     "## One Hot Encoding of categorical explanatory variables\n",
-    "Columns such as zip code and school district ID, which are integeres should not be fed into an ML model as integers.  Instead, we need to treat them as factors and perform one-hot encoding."
+    "Columns such as zip code and school district ID, which are integeres should not be fed into an ML model as integers.  Instead, we would need to treat them as factors and perform one-hot encoding.  "
    ]
   },
   {
@@ -190,6 +191,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "> **KEY OBSERVATION**: a hypothetical model that is hard-coded to predict a `negative` result every time would be ~77% accurate.  So, we should not accept any machine-learned model with a lower accuracy than that.  This also suggests that F1 score is a better metric to assess our work since it incorporates both precision and recall."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Train a \"naive\" multilayer perceptron model\n",
     "This first \"naive\" model uses all except for the SHSAT-related features, as described above.  We create a pipeline that will be used for k-fold cross-validation.  First, we scale the features, then estimate a multilayer perceptron neural network."
    ]
@@ -233,10 +241,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Train a \"race-blind\" multilayer perceptron model\n",
-    "Because we know there's an existing bias problem in the NYC schools, in that the demographics of the test taking population have been getting more homogenous, and the explicit goal of PASSNYC is to make the pool more diverse, we want to train a model that excludes most demographic features.  This would enable us to train a \"race-blind\" model.  \n",
-    "\n",
-    "### Preprocess new X_train and X_test datasets"
+    "## Train a \"naive\" model without zip code or school district\n",
+    "Next, we will remove the zip and district features and compare accuracy to the model that included one hot-encoded versions of these factors."
    ]
   },
   {
@@ -245,6 +251,105 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "drop_cols = ['dbn',\n",
+    "             'num_shsat_test_takers',\n",
+    "             'offers_per_student',\n",
+    "             'pct_test_takers',\n",
+    "             'high_registrations',\n",
+    "             'school_name',\n",
+    "             'school_income_estimate',\n",
+    "             'district',\n",
+    "             'zip',\n",
+    "            ]\n",
+    "\n",
+    "# drop SHSAT-related columns\n",
+    "X = df.drop(drop_cols, axis=1)\n",
+    "\n",
+    "# impute missing values by setting them to the column mean\n",
+    "imp = Imputer(missing_values='NaN', strategy='mean', axis=0)\n",
+    "imp.fit(X)\n",
+    "X_imputed = imp.transform(X)\n",
+    "print(X_imputed.shape)\n",
+    "\n",
+    "# split into training and test sets; make sure to stratify\n",
+    "X_train, X_test, y_train, y_test = util.our_train_test_split(X_imputed, y, stratify=y)\n",
+    "\n",
+    "# confirm stratification\n",
+    "print('Frac positive class in training set = %.3f' % (np.sum(y_train==1) / len(y_train)))\n",
+    "print('Frac positive class in test set = %.3f' % (np.sum(y_test==1) / len(y_test)))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# create a pipeline to run these in sequence\n",
+    "n_features = X_train.shape[1]\n",
+    "pipe_clf = make_pipeline(StandardScaler(with_mean=False), \n",
+    "                   MLPClassifier(hidden_layer_sizes=(n_features,n_features,n_features), max_iter=500))\n",
+    "\n",
+    "# Do k-fold cross-validation, collecting both \"test\" accuracy and F1 \n",
+    "k_folds=10\n",
+    "cv_scores = cross_validate(pipe_clf, X_train, y_train, cv=k_folds, scoring=['accuracy','f1'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# display accuracy with 95% confidence interval\n",
+    "cv_accuracy = cv_scores['test_accuracy']\n",
+    "print ('With %d-fold cross-validation, accuracy is: %.3f (95%% CI from %.3f to %.3f).' %\n",
+    "       (k_folds, cv_accuracy.mean(), cv_accuracy.mean() - 1.96 * cv_accuracy.std(),\n",
+    "        cv_accuracy.mean() + 1.96 * cv_accuracy.std()))\n",
+    "\n",
+    "# display F1 score with 95% confidence interval\n",
+    "cv_f1 = cv_scores['test_f1']\n",
+    "print ('The F1 score is: %.3f (95%% CI from %.3f to %.3f).' %\n",
+    "       (cv_f1.mean(), cv_f1.mean() - 1.96 * cv_f1.std(),\n",
+    "        cv_f1.mean() + 1.96 * cv_f1.std()))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> **KEY OBSERVATION**: while the accuracy is similar when we exclude zip code and school district, the F1 score is substantially less, with a 95% confidence interval that nearly spans the interval 0-1.  This suggests that it's important to keep these factors in the model. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Train a \"race-blind\" multilayer perceptron model\n",
+    "Because we know there's an existing bias problem in the NYC schools, in that the demographics of the test taking population have been getting more homogenous, and the explicit goal of PASSNYC is to make the pool more diverse, we want to train a model that excludes most demographic features.  This would enable us to train a \"race-blind\" model.  \n",
+    "\n",
+    "### Preprocess new X_train and X_test datasets\n",
+    "We will remove all explicitly demographic columns, as well as economic factors and zip code, which are likely highly correlated with demographics."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# drop SHSAT-related columns\n",
+    "drop_cols = ['dbn',\n",
+    "             'num_shsat_test_takers',\n",
+    "             'offers_per_student',\n",
+    "             'pct_test_takers',\n",
+    "             'high_registrations',\n",
+    "             'school_name',\n",
+    "             'school_income_estimate'\n",
+    "            ]\n",
+    "X = df.drop(drop_cols, axis=1)\n",
+    "\n",
+    "# drop additional (demographic) columns\n",
     "race_cols = ['percent_ell',\n",
     "             'percent_asian',\n",
     "             'percent_black',\n",
@@ -252,10 +357,8 @@
     "             'percent_black__hispanic',\n",
     "             'percent_white',\n",
     "             'economic_need_index',\n",
-    "             'school_income_estimate']\n",
-    "\n",
-    "\n",
-    "# drop additional (demographic) columns\n",
+    "             'zip'\n",
+    "             ]\n",
     "X_race_blind = X.drop(race_cols, axis=1)\n",
     "\n",
     "# impute missing values by setting them to the column mean\n",
@@ -264,7 +367,7 @@
     "X_race_blind_imputed = imp.transform(X_race_blind)\n",
     "\n",
     "# one-hot encode these features as factors\n",
-    "factor_cols = ['district', 'zip']\n",
+    "factor_cols = ['district']\n",
     "\n",
     "# get indices for these columns\n",
     "factor_col_ids = []\n",
@@ -318,6 +421,21 @@
     "print ('The F1 score is: %.3f (95%% CI from %.3f to %.3f).' %\n",
     "       (cv_f1.mean(), cv_f1.mean() - 1.96 * cv_f1.std(),\n",
     "        cv_f1.mean() + 1.96 * cv_f1.std()))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> **KEY OBSERVATION**: the F1 score for the race-blind model also have a 95% confidence interval that nearly spans the whole range from 0-1.  Of the models we have tested, the original \"naive\" model (with the most features) performs better than our race-blind model, or our model that excluded only zip and district."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Experiment with hidden layer parameters in the \"naive\" model\n",
+    "Next, we will return to the feature set of the original \"naive\" model, but will explore different numbers of h"
    ]
   },
   {


### PR DESCRIPTION
I added some more code to `model_neuralnet.ipynb`.  Highlights:

- My naive model (with one hot-encoded district and zipcode features) is still the best NN model.  One where I just removed zip and district, and my "race-blind" model both had worse F1 scores with confidence intervals from ~0-1.
- I'm still calculating accuracy, but given our train test split is ~77% positive cases, a "dumb" model that always predicted "negative" would have 77% accuracy.  So if our models achieve ~80% accuracy, that's not that great.  I think F1 score is probably a better gauge.
- I applied a new markdown format for "KEY OBSERVATIONS" that you might want to use into other notebooks.

The last material thing I am currently thinking about doing in the NN model is to try some different hidden layer parameters (with my "naive" feature set).
