### PR TITLE
util.get_dummies to replace util.oha_data

### DIFF
--- a/model_neuralnet.ipynb
+++ b/model_neuralnet.ipynb
@@ -171,7 +171,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "train_data_naive_ohe, test_data_naive_ohe = util.ohe_data(train_data_naive, test_data_naive)"
+    "# train_data_naive_ohe, test_data_naive_ohe = util.ohe_data(train_data_naive, test_data_naive)\n",
+    "train_data_naive_ohe, test_data_naive_ohe = util.get_dummies(train_data_naive, test_data_naive)\n",
+    "train_data_naive_ohe.head()"
    ]
   },
   {

--- a/model_neuralnet.py
+++ b/model_neuralnet.py
@@ -116,16 +116,18 @@ train_data_naive.head()
 # ## One Hot Encode the categorical explanatory variables
 # Columns such as zip code and school district ID, which are integeres should not be fed into an ML model as integers.  Instead, we would need to treat them as factors and perform one-hot encoding.  
 
-# In[6]:
+# In[7]:
 
 
-train_data_naive_ohe, test_data_naive_ohe = util.ohe_data(train_data_naive, test_data_naive)
+# train_data_naive_ohe, test_data_naive_ohe = util.ohe_data(train_data_naive, test_data_naive)
+train_data_naive_ohe, test_data_naive_ohe = util.get_dummies(train_data_naive, test_data_naive)
+train_data_naive_ohe.head()
 
 
 # ## Estimate the "naive" multilayer perceptron model
 # This first "naive" model uses all except for the SHSAT-related features, as described above.  We create a pipeline that will be used for k-fold cross-validation.  First, we scale the features, then estimate a multilayer perceptron neural network.
 
-# In[7]:
+# In[8]:
 
 
 # discard return vals; only print results
@@ -135,7 +137,7 @@ train_data_naive_ohe, test_data_naive_ohe = util.ohe_data(train_data_naive, test
 # ## Train a "naive" model without zip code or school district
 # Next, we will remove the zip and district features and compare accuracy to the model that included one hot-encoded versions of these factors.
 
-# In[8]:
+# In[ ]:
 
 
 drop_cols = ['dbn',
@@ -160,7 +162,7 @@ train_data_naive_nozip.head()
 # ## Estimate the "naive" multilayer perceptron model (without zip or district)
 # 
 
-# In[9]:
+# In[ ]:
 
 
 # discard return vals; only print results
@@ -175,7 +177,7 @@ train_data_naive_nozip.head()
 # ### Preprocess new X_train and X_test datasets
 # We will remove all explicitly demographic columns, as well as economic factors and zip code, which are likely highly correlated with demographics.
 
-# In[10]:
+# In[ ]:
 
 
 # drop SHSAT-related columns
@@ -210,7 +212,7 @@ train_data_race_blind_ohe, test_data_race_blind_ohe = util.ohe_data(train_data_n
 # ## Estimate the "race blind" multilayer perceptron model
 # 
 
-# In[11]:
+# In[ ]:
 
 
 # discard return vals; only print results
@@ -222,14 +224,14 @@ train_data_race_blind_ohe, test_data_race_blind_ohe = util.ohe_data(train_data_n
 # ## Experiment with dimensionality reduction via PCA
 # Since manual feature selection performed poorly, resulting in a confidence interval of F1 spanning from 0 to 1 in both cases, it doesn't seem to be a promising approach.  Next, we experiment with Principal Component Analysis for dimensionality reduction, starting with the "naive" set of columns.
 
-# In[12]:
+# In[ ]:
 
 
 # Determine the number of principal components to achieve 90% explained variance
 n_pca = util.get_num_pcas(train_data_naive, var_explained=0.9)
 
 
-# In[13]:
+# In[ ]:
 
 
 print('Using %d principal components' % (n_pca))
@@ -241,7 +243,7 @@ print('Using %d principal components' % (n_pca))
 # ## Use grid search to identify best set of hidden layer parameters
 # Since the usage of PCA seemed to improve our F1 score (and tighten its confidence interval), we will proceed to try to optimize the hidden layer parameters while using PCA.
 
-# In[14]:
+# In[ ]:
 
 
 # Running grid search for different combinations of neural network parameters is slow.

--- a/util.py
+++ b/util.py
@@ -58,6 +58,37 @@ our_train_test_split = partial(train_test_split,
                                random_state=RANDOM_STATE)
 
 
+def get_dummies(train_data, test_data, factor_cols=['zip','district']):
+    '''
+        inputs: train_data, test_data (pandas dataframes)
+        returns: train_data_ohe, test_data_ohe (pandas dataframes)
+        NOTE: any factors discovered in test set, which weren't in training, are ignored
+    '''
+
+    # don't alter incoming datasets unintentionally
+    train_data_ohe = train_data.copy(deep=False)
+    test_data_ohe = test_data.copy(deep=False)
+    
+    for f in factor_cols:
+        f_train_dummies = pd.get_dummies(train_data[f], prefix=f)
+        f_test_dummies = pd.get_dummies(test_data[f], prefix=f)
+        
+        # keep track of new columns from training set
+        new_columns = f_train_dummies.columns.values
+        train_data_ohe =  train_data_ohe.join(f_train_dummies, how="inner")
+        
+        # discard columns from test set not present in training set
+        intersect_columns = list(set(new_columns) & set(f_test_dummies.columns.values))
+        f_test_dummies = f_test_dummies[intersect_columns]
+        test_data_ohe =  test_data_ohe.join(f_test_dummies, how="inner")
+
+    print('Train data initial shape:',train_data.shape)
+    print('Test  data initial shape:',test_data.shape)
+    print('Train data OHE\'d shape:',train_data_ohe.shape)
+    print('Test  data OHE\'d shape:',test_data_ohe.shape)
+
+    return train_data_ohe, test_data_ohe
+    
 def get_num_pcas (train_data, var_explained=0.9):
     # Determine the number of principal components to achieve target explained variance
     cum_explained_variance_ratios = [0]
@@ -87,6 +118,7 @@ def get_num_pcas (train_data, var_explained=0.9):
 
 def ohe_data(train_data, test_data, factor_cols=['zip','district']):
     '''
+        DEPRECATED!!!! Use util.get_dummies(...) instead.
         inputs: train_data, test_data (pandas dataframes)
         returns: train_data_ohe, test_data_ohe (both sparse matrices)
     '''


### PR DESCRIPTION
I added a new function called `util.get_dummies(...)` which serves as a replacement for `util.oha_data(...)`.  It has the significant advantages of returning a pandas dataframe with intuitive column names (e.g. `zip_11369` or `district_28`).  

I left the deprecated `util.ohe_data(...)` function there so as to not break anybody's code, but I strongly encourage you to update to the new function.    Once everybody has updated, we can delete the deprecated function.

Successive sklearn calls are just as happy receiving dataframes as input as they were receiving a dense matrix, so it's trivial to change to the new function. Just swap the function name in your code (arguments are identical):

```train_data_naive_ohe, test_data_naive_ohe = util.get_dummies(train_data_naive, test_data_naive)
train_data_naive_ohe.head()```

