### PR TITLE
reduced wording in recommendations section

### DIFF
--- a/model_neuralnet.ipynb
+++ b/model_neuralnet.ipynb
@@ -499,7 +499,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Prioritized Engagement recommenda\n",
+    "## Prioritized Engagement recommendations\n",
     "\n",
     "Lastly, according to the methodology described in our [overview notebook](final_project_overview.ipynb), we will make our recommendations to PASSNYC based on an analysis of schools that the models show to have the highest opportunity to engage with Black and Hispanic students, in order to increase SHSAT registration in this population. We consider these to be the schools that are most likely to benefit from PASSNYC's intervention and engagement."
    ]

--- a/model_neuralnet.py
+++ b/model_neuralnet.py
@@ -30,7 +30,7 @@ from sklearn.preprocessing import StandardScaler
 pd.set_option('display.max_columns', None)
 pd.set_option('display.max_rows', 200)
 
-get_ipython().magic('matplotlib inline')
+get_ipython().run_line_magic('matplotlib', 'inline')
 
 
 # ## Load data and split class labels into separate array
@@ -360,7 +360,7 @@ print('False positives: %d\n' % (fp))
 print(classification_report(test_labels, test_predict))
 
 
-# ## Prioritized Engagement recommenda
+# ## Prioritized Engagement recommendations
 # 
 # Lastly, according to the methodology described in our [overview notebook](final_project_overview.ipynb), we will make our recommendations to PASSNYC based on an analysis of schools that the models show to have the highest opportunity to engage with Black and Hispanic students, in order to increase SHSAT registration in this population. We consider these to be the schools that are most likely to benefit from PASSNYC's intervention and engagement.
 


### PR DESCRIPTION
Since @omsteadily did such a thorough writeup about the prioritization logic, I decided to strip mine out of `model_neuralnet` and just refer back to that description.  I replaced my verbage with the following text, which you might want to just copy @andrewlarimer @deepix :

## Prioritized engagement recommendations

Lastly, we will make our recommendations to PASSNYC based on an analysis of schools that the models show to have the highest opportunity to engage with Black and Hispanic students, in order to increase SHSAT registration in this population. We consider these to be the schools that are most likely to benefit from PASSNYC's intervention and engagement.  Our methodology is described in detail in the [final_project_overview](final_project_overview.ipynb) notebook.